### PR TITLE
TinyUSB 0.14.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+straithe@greatscottgadgets.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2020-2021, Great Scott Gadgets
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apollo_fpga/__init__.py
+++ b/apollo_fpga/__init__.py
@@ -238,3 +238,8 @@ class ApolloDebugger:
             self.out_request(self.REQUEST_FORCE_FPGA_OFFLINE)
         except usb.core.USBError:
             pass
+
+    def close(self):
+        """ Closes the USB device so it can be reused, possibly by another ApolloDebugger """
+
+        usb.util.dispose_resources(self.device)

--- a/apollo_fpga/ila.py
+++ b/apollo_fpga/ila.py
@@ -6,6 +6,9 @@
 
 """ Apollo-based ILA transports. """
 
+import math
+import sys
+
 from abc           import ABCMeta, abstractmethod
 
 from vcd           import VCDWriter

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -53,6 +53,7 @@ endif
 
 CFLAGS += \
 	-Wno-unused-parameter \
+	-Wno-cast-qual \
 	-fstrict-volatile-bitfields \
 	-D_BOARD_REVISION_MAJOR_=$(BOARD_REVISION_MAJOR) \
 	-D_BOARD_REVISION_MINOR_=$(BOARD_REVISION_MINOR) \

--- a/firmware/src/boards/luna_d11/dfu.c
+++ b/firmware/src/boards/luna_d11/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/luna_d11/tusb_config.h
+++ b/firmware/src/boards/luna_d11/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/luna_d21/dfu.c
+++ b/firmware/src/boards/luna_d21/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/luna_d21/tusb_config.h
+++ b/firmware/src/boards/luna_d21/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/samd11_xplained/dfu.c
+++ b/firmware/src/boards/samd11_xplained/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/samd11_xplained/tusb_config.h
+++ b/firmware/src/boards/samd11_xplained/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/jtag_tap.c
+++ b/firmware/src/jtag_tap.c
@@ -178,13 +178,17 @@ void jtag_deinit(void)
 }
 
 
-
+static inline void delay(int cycles)
+{
+	while (cycles-- != 0)
+		__NOP();
+}
 
 
 static inline void jtag_pulse_clock(void)
 {
 	gpio_set_pin_level(TCK_GPIO, false);
-	__NOP();
+	delay(10);
 	gpio_set_pin_level(TCK_GPIO, true);
 }
 
@@ -193,7 +197,7 @@ static inline uint8_t jtag_pulse_clock_and_read_tdo(void)
 	uint8_t ret;
 
 	gpio_set_pin_level(TCK_GPIO, false);
-	__NOP();
+	delay(10);
 	ret = jtag_read_tdo();
 	gpio_set_pin_level(TCK_GPIO, true);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "apollo-fpga"
 version = "0.0.5"
 description = "host tools for Apollo FPGA debug controllers"
-authors = ["Katherine Temkin <k@ktemkin.com>"]
+authors = ["Great Scott Gadgets <info@greatscottgadgets.com>"]
 license = "BSD"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apollo-fpga"
-version = "0.0.4"
+version = "0.0.5"
 description = "host tools for Apollo FPGA debug controllers"
 authors = ["Katherine Temkin <k@ktemkin.com>"]
 license = "BSD"

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     name='apollo-fpga',
     license='BSD',
     url='https://github.com/greatscottgadgets/apollo',
-    author='Katherine J. Temkin',
-    author_email='ktemkin@greatscottgadgets.com',
+    author='Great Scott Gadgets',
+    author_email='info@greatscottgadgets.com',
     description='host tools for Apollo FPGA debug controllers',
     use_scm_version= {
         "root": '..',


### PR DESCRIPTION
Switch to TinyUSB 0.14.0

updates `lib/tinyusb` submodule to 0.14.0 and adapts board source files accordingly
firmware for daisho couldn't be build to to missing bsp in TinyUSB

current TinyUSB submodule makes building for ESP32-S2 quite hard